### PR TITLE
Fixes path for BuildDotenvConfig.ruby on project.pbxproj

### DIFF
--- a/ios/ReactNativeConfig.xcodeproj/project.pbxproj
+++ b/ios/ReactNativeConfig.xcodeproj/project.pbxproj
@@ -143,7 +143,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/Users/pedro/dev/lugg/react-native-config/ios/ReactNativeConfig/BuildDotenvConfig.ruby";
+			shellScript = "./ReactNativeConfig/BuildDotenvConfig.ruby";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Hi @pedro!

I've found a fixed path on project.pbxproj that was preventing from compiling iOS projects ;)