### PR TITLE
Merge together the index files for easier testing

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -1,5 +1,0 @@
-'use strict';
-
-// bridge to the buildConfigField vars set in build.gradle, and exported via ReactConfig
-var React = require('react-native');
-module.exports = React.NativeModules.ReactNativeConfig;

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,5 +1,0 @@
-'use strict';
-
-// bridge to the config vars set in xcconfig and exposed via ReactNativeConfig.m
-var React = require('react-native');
-module.exports = React.NativeModules.ReactNativeConfig;

--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+// Bridge to:
+// Android: buildConfigField vars set in build.gradle, and exported via ReactConfig
+// iOS: config vars set in xcconfig and exposed via ReactNativeConfig.m
+var React = require('react-native');
+module.exports = React.NativeModules.ReactNativeConfig;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-config",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Expose config variables to React Native apps",
   "keywords": ["env", "config", "config-var", "react-native", "android", "ios", "12factor"],
   "homepage": "https://github.com/luggg/react-native-config",
@@ -8,8 +8,7 @@
   "files": [
     "android/",
     "ios/",
-    "index.android.js",
-    "index.ios.js"
+    "index.js"
   ],
   "license": "MIT"
 }


### PR DESCRIPTION
Hi,

Don't know if this interests you but I have been trying to test with mocha and having problems (as it doesn't understand react-native and therefore the platform files). Merging these two files seems to work for me and allows mocha to require them directly. This means I can mock out the library successfully.

Was wondering what your reasons where for keeping them apart?

Thanks,